### PR TITLE
Encapsulate remaining adapter.PersistenceLayers in "futures"

### DIFF
--- a/internal/popple/popple.go
+++ b/internal/popple/popple.go
@@ -119,3 +119,14 @@ func GetLeaderboard(pl adapter.PersistenceLayer, serverID string, top bool, limi
 	}()
 	return f
 }
+
+type SetAnnounceF chan error
+
+func SetAnnounce(pl adapter.PersistenceLayer, serverID string, on bool) SetAnnounceF {
+	f := make(chan error, 1)
+	go func() {
+		_ = pl.CreateConfig(serverID)
+		f <- pl.PutConfig(adapter.Config{ServerID: serverID, NoAnnounce: !on})
+	}()
+	return f
+}

--- a/popple.go
+++ b/popple.go
@@ -87,8 +87,7 @@ func (p *Popple) SetAnnounce(serverID string, body io.Reader) error {
 		return ErrInvalidAnnounceSetting
 	}
 
-	_ = p.pl.CreateConfig(serverID)
-	return p.pl.PutConfig(adapter.Config{ServerID: serverID, NoAnnounce: !on})
+	return <-popple.SetAnnounce(p.pl, serverID, on)
 }
 
 func (p *Popple) Karma(serverID string, body io.Reader) (map[string]int, error) {

--- a/popple.go
+++ b/popple.go
@@ -46,24 +46,10 @@ func (p *Popple) BumpKarma(serverID string, body io.Reader) (map[string]int, boo
 
 	bumps := karma.Parse(text.String())
 
-	levels := make(map[string]int)
-	for n, k := range bumps {
-		if k == 0 {
-			continue
-		}
-
-		updated, err := p.pl.AddKarmaToEntity(
-			adapter.Entity{
-				Name:     n,
-				ServerID: serverID,
-			},
-			k,
-		)
-		if err != nil {
-			return nil, false, err
-		}
-
-		levels[n] = int(updated.Karma)
+	newlvlsr := <-popple.AddKarmaToEntities(p.pl, serverID, bumps)
+	levels, err := newlvlsr.Levels, newlvlsr.Err
+	if err != nil {
+		return nil, false, err
 	}
 
 	cfgr := <-cfgf


### PR DESCRIPTION
Since client code can pass anything that implements adapter.PersistenceLayer, there's no knowing just how long any of those operations can take. One's adapter.PersistenceLayer may include a number of lengthy calls over a network, etc.

Encapsulate the remaining calls to adapter.PersistenceLayer in pseudo-futures so that Popple application code can choose when to block on the result.